### PR TITLE
Fix detection of empty release notes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,9 @@ author: Stefan Zweifel <hello@stefanzweifel.io>
 
 inputs:
   release-notes:
-    required: true
+    required: false
     description: The release notes you want to add to your CHANGELOG. Should be markdown.
+    default: null
   latest-version:
     required: true
     description: Semantic version number of the latest release. The value will be used as a heading text.

--- a/composer.lock
+++ b/composer.lock
@@ -756,16 +756,16 @@
         },
         {
             "name": "wnx/changelog-updater",
-            "version": "v1.4.0",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stefanzweifel/php-changelog-updater.git",
-                "reference": "7b9ea1ce4de0e850bfecdc442108fd75e1ba7de8"
+                "reference": "8c4fa385e4b76c79dbedd0710b50dffd810706ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stefanzweifel/php-changelog-updater/zipball/7b9ea1ce4de0e850bfecdc442108fd75e1ba7de8",
-                "reference": "7b9ea1ce4de0e850bfecdc442108fd75e1ba7de8",
+                "url": "https://api.github.com/repos/stefanzweifel/php-changelog-updater/zipball/8c4fa385e4b76c79dbedd0710b50dffd810706ec",
+                "reference": "8c4fa385e4b76c79dbedd0710b50dffd810706ec",
                 "shasum": ""
             },
             "require": {
@@ -821,7 +821,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-19T19:01:06+00:00"
+            "time": "2022-03-20T06:30:18+00:00"
         },
         {
             "name": "wnx/commonmark-markdown-renderer",


### PR DESCRIPTION
Update the CLI to [`v1.4.1`](https://github.com/stefanzweifel/php-changelog-updater/pull/19) to fix an issue with empty release-notes detection and mark `release-notes`as optional in `action.yml`.

See https://github.com/stefanzweifel/changelog-updater-action/issues/12#issuecomment-1073115279