### PR TITLE
Add `hide-release-date` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     description: Text used in the new release heading. Defaults to the value from latest-version.
   hide-release-date:
     required: false
-    default: false
+    default: null
     description: Hide release date in the new release heading.
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     required: false
     default: null
     description: Text used in the new release heading. Defaults to the value from latest-version.
+  hide-release-date:
+    required: false
+    default: false
+    description: Hide release date in the new release heading.
 
 outputs:
   release_compare_url:
@@ -50,3 +54,4 @@ runs:
     - ${{ inputs.path-to-changelog }}
     - ${{ inputs.compare-url-target-revision }}
     - ${{ inputs.heading-text }}
+    - ${{ inputs.hide-release-date }}

--- a/composer.lock
+++ b/composer.lock
@@ -678,16 +678,16 @@
         },
         {
             "name": "wnx/changelog-updater",
-            "version": "v1.7.0",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stefanzweifel/php-changelog-updater.git",
-                "reference": "c75fb2f6d414465e78bb562203c9c5011b3894bb"
+                "reference": "2e61db2bbad6c3811f069bacb3c14ca0626cbfe3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stefanzweifel/php-changelog-updater/zipball/c75fb2f6d414465e78bb562203c9c5011b3894bb",
-                "reference": "c75fb2f6d414465e78bb562203c9c5011b3894bb",
+                "url": "https://api.github.com/repos/stefanzweifel/php-changelog-updater/zipball/2e61db2bbad6c3811f069bacb3c14ca0626cbfe3",
+                "reference": "2e61db2bbad6c3811f069bacb3c14ca0626cbfe3",
                 "shasum": ""
             },
             "require": {
@@ -745,7 +745,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-22T09:10:58+00:00"
+            "time": "2023-05-29T11:58:32+00:00"
         },
         {
             "name": "wnx/commonmark-markdown-renderer",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ php /changelog-updater update \
 --path-to-changelog="$4" \
 --compare-url-target-revision="$5" \
 --heading-text="$6" \
+--hide-release-date="$7" \
 --github-actions-output \
 --write \
 --no-interaction

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ php /changelog-updater update \
 --path-to-changelog="$4" \
 --compare-url-target-revision="$5" \
 --heading-text="$6" \
---hide-release-date="$7" \
+$( [ "$7" ] && echo "--hide-release-date" ) \
 --github-actions-output \
 --write \
 --no-interaction


### PR DESCRIPTION
Update Action to expose the `--hide-release-date` option that has been added to the underlying CLI.


- https://github.com/stefanzweifel/php-changelog-updater/pull/39
- https://github.com/stefanzweifel/php-changelog-updater/discussions/36