### PR TITLE
Add support for new `--parse-github-usernames` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     required: false
     default: null
     description: Hide release date in the new release heading.
+  parse-github-usernames:
+    required: false
+    default: null
+    description: "Experimental: Find GitHub usernames in release notes and link to their profile."
 
 outputs:
   release_compare_url:
@@ -55,3 +59,4 @@ runs:
     - ${{ inputs.compare-url-target-revision }}
     - ${{ inputs.heading-text }}
     - ${{ inputs.hide-release-date }}
+    - ${{ inputs.parse-github-usernames }}

--- a/composer.lock
+++ b/composer.lock
@@ -470,16 +470,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.2.1",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
-                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
@@ -488,7 +488,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -517,7 +517,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -533,7 +533,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T10:25:55+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -678,16 +678,16 @@
         },
         {
             "name": "wnx/changelog-updater",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stefanzweifel/php-changelog-updater.git",
-                "reference": "2e61db2bbad6c3811f069bacb3c14ca0626cbfe3"
+                "reference": "2b0d38f563879816fb833c1ca4312187be442807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stefanzweifel/php-changelog-updater/zipball/2e61db2bbad6c3811f069bacb3c14ca0626cbfe3",
-                "reference": "2e61db2bbad6c3811f069bacb3c14ca0626cbfe3",
+                "url": "https://api.github.com/repos/stefanzweifel/php-changelog-updater/zipball/2b0d38f563879816fb833c1ca4312187be442807",
+                "reference": "2b0d38f563879816fb833c1ca4312187be442807",
                 "shasum": ""
             },
             "require": {
@@ -698,8 +698,8 @@
                 "wnx/commonmark-markdown-renderer": "^1.0.2"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.12",
                 "laravel-zero/framework": "^10",
+                "laravel/pint": "^1.10",
                 "mockery/mockery": "^1.5.1",
                 "pestphp/pest": "^2",
                 "rector/rector": "^0.15.24",
@@ -745,7 +745,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-29T11:58:32+00:00"
+            "time": "2023-07-02T07:48:40+00:00"
         },
         {
             "name": "wnx/commonmark-markdown-renderer",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ php /changelog-updater update \
 --compare-url-target-revision="$5" \
 --heading-text="$6" \
 $( [ "$7" ] && echo "--hide-release-date" ) \
+$( [ "$8" ] && echo "--parse-github-usernames" ) \
 --github-actions-output \
 --write \
 --no-interaction


### PR DESCRIPTION
This PR updates the action to use the latest version of the underlying CLI to support the new `--parse-github-usernames` option that has been added in https://github.com/stefanzweifel/php-changelog-updater/pull/41.